### PR TITLE
Swith fontawesome from in-line to css import

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -40,7 +40,7 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "550kb",
+                  "maximumWarning": "650kb",
                   "maximumError": "1mb"
                 },
                 {

--- a/src/app/components/toolbar/toolbar.component.ts
+++ b/src/app/components/toolbar/toolbar.component.ts
@@ -1,8 +1,11 @@
 import { Component } from '@angular/core';
 import { RouterOutlet, RouterLink } from '@angular/router';
 import { NgIf } from '@angular/common';
+
+import { config } from '@fortawesome/fontawesome-svg-core';
 import { faFacebook, faInstagram, faTiktok, faThreads, faYoutube, faDiscord } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome'
+config.autoAddCss = false;
 
 import { MatToolbar, MatToolbarRow } from '@angular/material/toolbar';
 import { MatButton } from '@angular/material/button';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -7,6 +7,7 @@
 // have to load a single css file for Angular Material in your app.
 // Be sure that you only ever include this mixin once!
 @include mat.core();
+@import "@fortawesome/fontawesome-svg-core/styles.css";
 
 // Define the palettes for your theme using the Material Design palettes available in palette.scss
 // (imported above). For each palette, you can optionally specify a default, lighter, and darker


### PR DESCRIPTION
Fixes conflict with CSP. By default, fontawesome injects inline CSS which is blocked when nonce is present.